### PR TITLE
Add per-service structure explanations

### DIFF
--- a/dkr-ftp/README.md
+++ b/dkr-ftp/README.md
@@ -1,0 +1,27 @@
+# dkr-ftp
+
+Configuración de un servidor FTP sencillo basado en **vsftpd**.
+
+El contenedor expone el puerto estándar 21 y un rango de puertos pasivos para facilitar la conexión desde clientes externos. Los valores de usuario y contraseña, así como el directorio compartido, se definen en el archivo `.env` y en el `docker-compose.yml`.
+
+La variable `PHP_APP_PATH` indica la ruta que se montará como raíz del usuario FTP.
+
+## Estructura
+
+```
+dkr-ftp/
+├── docker-compose.yml  # define el servicio vsftpd y sus variables
+└── README.md           # documentación del contenedor
+```
+
+Cada archivo cumple el rol de describir y orquestar el contenedor FTP.
+
+## Uso
+
+1. Edita `.env` y ajusta `PHP_APP_PATH` según tu proyecto.
+2. Ejecuta:
+   ```bash
+   docker compose up -d
+   ```
+   El contenedor `ftp` quedará listo para aceptar conexiones.
+

--- a/dkr-php/README.md
+++ b/dkr-php/README.md
@@ -1,0 +1,33 @@
+# dkr-php
+
+Este directorio contiene la configuración necesaria para levantar un entorno PHP con Nginx utilizando Docker Compose.
+
+- **php**: se construye desde `php/Dockerfile` e instala PHP-FPM 8.4 con extensiones comunes y soporte para SQL Server.
+- **nginx**: sirve la aplicación y expone el puerto **8080** en el host.
+
+El código de tu aplicación se monta en `/var/www` dentro de los contenedores usando la variable `PHP_APP_PATH` definida en el archivo `.env` local.
+
+## Estructura
+
+```
+dkr-php/
+├── docker-compose.yml  # orquesta los servicios PHP y Nginx
+├── php/
+│   └── dockerfile      # imagen personalizada con extensiones
+├── data/
+│   └── nginx/
+│       └── default.conf  # configuración de Nginx
+└── README.md
+```
+
+Estos archivos permiten construir la imagen de PHP, configurar Nginx y levantar el entorno completo con Docker Compose.
+
+## Uso
+
+1. Ajusta la ruta `PHP_APP_PATH` en `.env` para que apunte al directorio de tu aplicación.
+2. Ejecuta:
+   ```bash
+   docker compose up -d
+   ```
+   Esto iniciará los contenedores `php` y `nginx`.
+

--- a/dkr-sql/README.md
+++ b/dkr-sql/README.md
@@ -1,0 +1,32 @@
+# dkr-sql
+
+Incluye la configuración para ejecutar Microsoft SQL Server 2022 junto con un contenedor auxiliar de copias de seguridad.
+
+- **sqlserver**: contenedor oficial que expone el puerto **1433**.
+- **sql-backup**: utiliza los scripts en `backup/` para generar respaldos automáticos mediante cron.
+
+Las credenciales y rutas se definen en el archivo `.env`, que contiene variables como `SA_PASSWORD`, `SQL_USER`, `SQL_DB`, `SQL_SERVER` y `SQL_BACKUP_PATH`.
+
+## Estructura
+
+```
+dkr-sql/
+├── docker-compose.yml  # define SQL Server y contenedor de respaldo
+├── backup/
+│   ├── Dockerfile  # imagen para las tareas de backup
+│   ├── backup.sh   # script que realiza las copias
+│   └── crontab.txt # programación de cron
+└── README.md
+```
+
+Esta estructura organiza tanto el contenedor principal de SQL Server como el servicio auxiliar encargado de las copias de seguridad automáticas.
+
+## Uso
+
+1. Ajusta las variables del archivo `.env`.
+2. Levanta los servicios con:
+   ```bash
+   docker compose up -d
+   ```
+   Esto iniciará `sqlserver` y el servicio de backup.
+


### PR DESCRIPTION
## Summary
- expand PHP, SQL and FTP service docs with tree view of their files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a86c5d08832dbb96c83f9af7f550