### PR TITLE
Fix PHP Docker build settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker-linsock-services/
 │   │   └── nginx/
 │   │       └── default.conf
 │   └── php/
-│       └── dockerfile
+│       └── Dockerfile
 ├── dkr-sql/
 │   ├── docker-compose.yml
 │   └── backup/

--- a/dkr-php/README.md
+++ b/dkr-php/README.md
@@ -2,7 +2,7 @@
 
 Este directorio contiene la configuración necesaria para levantar un entorno PHP con Nginx utilizando Docker Compose.
 
-- **php**: se construye desde `php/Dockerfile` e instala PHP-FPM 8.4 con extensiones comunes y soporte para SQL Server.
+- **php**: se construye desde `php/Dockerfile` e instala PHP-FPM 8.3 con extensiones comunes y soporte para SQL Server.
 - **nginx**: sirve la aplicación y expone el puerto **8080** en el host.
 
 El código de tu aplicación se monta en `/var/www` dentro de los contenedores usando la variable `PHP_APP_PATH` definida en el archivo `.env` local.
@@ -13,7 +13,7 @@ El código de tu aplicación se monta en `/var/www` dentro de los contenedores u
 dkr-php/
 ├── docker-compose.yml  # orquesta los servicios PHP y Nginx
 ├── php/
-│   └── dockerfile      # imagen personalizada con extensiones
+│   └── Dockerfile      # imagen personalizada con extensiones
 ├── data/
 │   └── nginx/
 │       └── default.conf  # configuración de Nginx

--- a/dkr-php/php/Dockerfile
+++ b/dkr-php/php/Dockerfile
@@ -1,5 +1,5 @@
-# Imagen base de PHP 8.4 con FPM en Alpine
-FROM php:8.4-fpm-alpine
+# Imagen base de PHP 8.3 con FPM en Alpine
+FROM php:8.3-fpm-alpine
 
 # Aceptar EULA de Microsoft
 ENV ACCEPT_EULA=Y


### PR DESCRIPTION
## Summary
- rename Dockerfile to match docker-compose path
- update PHP base image to 8.3
- adjust docs for new Dockerfile name and version

## Testing
- `docker compose -f dkr-php/docker-compose.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c71736d8832dbf4a04de1efa521f